### PR TITLE
builtin.ts: treat EXAMPLES_PATH as relative to app root.

### DIFF
--- a/lib/sources/builtin.ts
+++ b/lib/sources/builtin.ts
@@ -26,11 +26,12 @@ import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';
 
+import * as utils from '../utils.js';
 import * as props from '../properties.js';
 
 import type {Source, SourceEntry} from './index.js';
 
-const EXAMPLES_PATH = props.get('builtin', 'sourcePath', './examples/');
+const EXAMPLES_PATH = utils.resolvePathFromAppRoot(props.get('builtin', 'sourcePath', './examples/'));
 const NAME_SUBSTUTION_PATTERN = new RegExp('_', 'g');
 const ALL_EXAMPLES: SourceEntry[] = fs.readdirSync(EXAMPLES_PATH).flatMap(folder => {
     // Recurse through the language folders


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
